### PR TITLE
Performance fix of Download/Export component.

### DIFF
--- a/src/debtors/components/download.tsx
+++ b/src/debtors/components/download.tsx
@@ -12,13 +12,13 @@ interface ExportProps<TData> {
 }
 
 export function Download<TData>({ table, exportName }: ExportProps<TData>) {
-  const data = getData(table);
   const { t } = useTranslation();
   const config = mkConfig({
     useKeysAsHeaders: true,
     filename: exportName,
   });
   const downloadData = async () => {
+    const data = getData(table);
     const csv = generateCsv(config)(data);
     download(config)(csv);
     return;


### PR DESCRIPTION
The Download/Export component was harming the performance of the parent widgets/route page because the "getData" function was being called in every re-render of the component. The table data is only needed when the user clicks on "Export" button.

Render time before fix:

![Captura de ecrã 2024-04-03, às 16 20 24](https://github.com/franciscobmacedo/debtors/assets/38112456/3aeb71fe-b874-4153-ac6c-45e682a7262f)
